### PR TITLE
Avoid using else after rescue if it's not really needed

### DIFF
--- a/lib/disyuntor.rb
+++ b/lib/disyuntor.rb
@@ -70,23 +70,17 @@ class Disyuntor
   end
 
   def on_circuit_closed(&block)
-    ret = block.call
+    block.call.tap { close! }
   rescue
     @failures += 1
     open! if @failures > @threshold
     raise
-  else
-    close!
-    ret
   end
 
   def on_circuit_half_open(&block)
-    ret = block.call
+    block.call.tap { close! }
   rescue
     open!
     raise
-  else
-    close!
-    ret
   end
 end


### PR DESCRIPTION
The flow will continue as usual if an exception has not been raised, so in this case there's no need for an `else` clause right after the `rescue` block.
