### PR TITLE
Refactor: circuit state callbacks

### DIFF
--- a/lib/disyuntor.rb
+++ b/lib/disyuntor.rb
@@ -5,15 +5,11 @@ class Disyuntor
 
   attr_reader :failures, :opened_at, :threshold, :timeout
 
-  def initialize(threshold: 5, timeout: 10, &block)
+  def initialize(threshold: 5, timeout: 10)
     @threshold = threshold
     @timeout   = timeout
 
-    @on_circuit_open = if block_given?
-                         block
-                       else
-                         Proc.new{ fail CircuitOpenError }
-                       end
+    @on_circuit_open = Proc.new{ fail CircuitOpenError }
 
     close!
   end

--- a/lib/disyuntor.rb
+++ b/lib/disyuntor.rb
@@ -9,7 +9,7 @@ class Disyuntor
     @threshold = threshold
     @timeout   = timeout
 
-    @on_circuit_open = Proc.new{ fail CircuitOpenError }
+    on_circuit_open { fail CircuitOpenError }
 
     close!
   end
@@ -53,7 +53,7 @@ class Disyuntor
     case
     when closed?    then on_circuit_closed(&block)
     when half_open? then on_circuit_half_open(&block)
-    when open?      then on_circuit_open
+    when open?      then circuit_open
     end
   end
 
@@ -79,10 +79,11 @@ class Disyuntor
   end
 
   def on_circuit_open(&block)
-    if block_given?
-      @on_circuit_open = block
-    else
-      @on_circuit_open.(self)
-    end
+    raise ArgumentError, "Must pass a block" unless block_given?
+    @on_circuit_open = block
+  end
+
+  def circuit_open
+    @on_circuit_open.call(self)
   end
 end

--- a/lib/disyuntor.rb
+++ b/lib/disyuntor.rb
@@ -51,13 +51,13 @@ class Disyuntor
     half_open! if timed_out?
 
     case
-    when closed?    then on_circuit_closed(&block)
-    when half_open? then on_circuit_half_open(&block)
+    when closed?    then circuit_closed(&block)
+    when half_open? then circuit_half_open(&block)
     when open?      then circuit_open
     end
   end
 
-  def on_circuit_closed(&block)
+  def circuit_closed(&block)
     ret = block.call
   rescue
     @failures += 1
@@ -68,7 +68,7 @@ class Disyuntor
     ret
   end
 
-  def on_circuit_half_open(&block)
+  def circuit_half_open(&block)
     ret = block.call
   rescue
     open!

--- a/spec/disyuntor_spec.rb
+++ b/spec/disyuntor_spec.rb
@@ -21,7 +21,7 @@ describe Disyuntor do
 
     it "should set default circuit open fallback" do
       assert_raises(Disyuntor::CircuitOpenError) do
-        circuit.on_circuit_open
+        circuit.circuit_open
       end
     end
 

--- a/spec/disyuntor_spec.rb
+++ b/spec/disyuntor_spec.rb
@@ -26,16 +26,10 @@ describe Disyuntor do
     end
 
     it "should override defaults" do
-      circuit = Disyuntor.new(threshold: 20, timeout: 60) do
-        fail RuntimeError
-      end
+      circuit = Disyuntor.new(threshold: 20, timeout: 60)
 
       assert_equal 20, circuit.threshold
       assert_equal 60, circuit.timeout
-
-      assert_raises(RuntimeError) do
-        circuit.on_circuit_open
-      end
     end
   end
 


### PR DESCRIPTION
After some discussion with @matflores and @fsaravia about the callback names, I've decided to rename the callbacks and remove the double functionality of `#on_circuit_open`.
