### PR TITLE
Ensure exactly one #try executes while timed out

### DIFF
--- a/lib/disyuntor.rb
+++ b/lib/disyuntor.rb
@@ -13,7 +13,10 @@ class Disyuntor
   end
 
   def try(&block)
-    if closed? or timed_out?
+    if closed?
+      circuit_closed(&block)
+    elsif timed_out?
+      open!
       circuit_closed(&block)
     else
       circuit_open


### PR DESCRIPTION
When the circuit is open and the time out period has passed a call to `#try` executes the block as a trial. This is intended to happen only once. Currently this can happen more than once when (1) a
trial is "in progress" in a background thread.

The reason is that `#timed_out?` checks `@opened_at`, which isn't updated until the trial finishes. `#timed_out?` will always be`true` while a trial is in progress.

Calling `#open!` before performing the trial ensures a second call to `#try` will not result in a trial since `#timed_out` is no longer `true`.